### PR TITLE
Fix redundant match by mdfind

### DIFF
--- a/xcode_toggleImplAndTests.scpt
+++ b/xcode_toggleImplAndTests.scpt
@@ -24,8 +24,8 @@ on run
 		# display dialog destinationName
 		
 		# ファイルパスを探して開く
-		set command to "/usr/bin/mdfind -onlyin " & quoted form of projectFolder & " -name " & quoted form of destinationName
 		# display dialog command
+		set command to "find " & quoted form of projectFolder & " -name " & quoted form of destinationName
 		set destinationPath to do shell script command
 		if length of destinationPath > 0 then
 			open destinationPath


### PR DESCRIPTION
If you have `AlertRecipe.swift` and `DescriptiveAlertRecipe.swift`, toggling in `AlertRecipeTests.swift` confuses script because `mdfind` matches both Tests files by `-name AlertTests.swift`.
```
$ /usr/bin/mdfind -onlyin '/Users/toshi0383/github/TVMLKitchen' -name 'AlertRecipe.swift'
/Users/toshi0383/github/TVMLKitchen/Sources/Recipes/AlertRecipe.swift
/Users/toshi0383/github/TVMLKitchen/Sources/Recipes/DescriptiveAlertRecipe.swift
```
By using `/usr/bin/find`, `-name AlertTests.swift` matches only the latter one in this case.
```
$ /usr/bin/find '/Users/toshi0383/github/TVMLKitchen' -name 'AlertRecipe.swift'
/Users/toshi0383/github/TVMLKitchen/Sources/Recipes/AlertRecipe.swift
```